### PR TITLE
fix: powershell debug did not work with new console in windows 11

### DIFF
--- a/ExampleBlishhudModule/Properties/launchSettings.json
+++ b/ExampleBlishhudModule/Properties/launchSettings.json
@@ -8,7 +8,7 @@
     "powershell": {
       "commandName": "Executable",
       "executablePath": "C:\\gw2\\Blish.HUD\\Blish HUD.exe",
-      "commandLineArgs": "--debug --process powershell --window ConsoleWindowClass --module \"$(ProjectDir)\\$(BaseOutputPath)\\$(Configuration)/$(TargetFramework)\\$(TargetName).bhm\" --settings \"..\\Settings_$(TargetName)\""
+      "commandLineArgs": "--debug --process WindowsTerminal --window CASCADIA_HOSTING_WINDOW_CLASS --module \"$(ProjectDir)\\$(BaseOutputPath)\\$(Configuration)/$(TargetFramework)\\$(TargetName).bhm\" --settings \"..\\Settings_$(TargetName)\""
     }
   }
 }


### PR DESCRIPTION
windows 11 now uses a new type of window for CMD and Powershell. That broke the "powershell" debug profile in the launchSettings.json. This PR fixes the issue