### PR TITLE
Fix typo in manifest.json key

### DIFF
--- a/ExampleBlishhudModule/manifest.json
+++ b/ExampleBlishhudModule/manifest.json
@@ -23,7 +23,7 @@
   ],
 
   "directories": [ "example-module-data" ],
-  "enabled_without_gw2": false,
+  "enable_without_gw2": false,
 
   "api_permissions": {
     "account": {


### PR DESCRIPTION
I don't know why it's different from the property name (probably a typo), but this is the proper key name.

https://github.com/blish-hud/Blish-HUD/blob/f23f409dc1bfeb31e7193427c1fcb864752b9d07/Blish%20HUD/GameServices/Modules/Manifest.cs#L50